### PR TITLE
Log more specific errors

### DIFF
--- a/formPix/app.js
+++ b/formPix/app.js
@@ -568,16 +568,16 @@ app.use(async (req, res, next) => {
 			}
 		});
 
-		// Check if the response status is not 200
-		// If a user is not allowed to access the endpoint, this will also be triggered
-		if (response.status != 200) {
-			res.status(response.status).json({ message: response.statusText })
-			return
-		}
-
 		let data = await response.json();
 		if (data.error) {
 			res.status(response.status).json({ status: data.error })
+			return
+		}
+
+		// Check if the response status is not 200
+		// If there was a problem that did not have an error message, this will trigger
+		if (response.status !== 200) {
+			res.status(response.status).json({ message: response.statusText, data })
 			return
 		}
 

--- a/formPixSim/app.js
+++ b/formPixSim/app.js
@@ -594,16 +594,16 @@ app.use(async (req, res, next) => {
 			}
 		});
 
-		// Check if the response status is not 200
-		// If a user is not allowed to access the endpoint, this will also be triggered
-		if (response.status != 200) {
-			res.status(response.status).json({ message: response.statusText })
-			return
-		}
-
 		let data = await response.json();
 		if (data.error) {
 			res.status(response.status).json({ status: data.error })
+			return
+		}
+
+		// Check if the response status is not 200
+		// If there was a problem that did not have an error message, this will trigger
+		if (response.status !== 200) {
+			res.status(response.status).json({ message: response.statusText, data })
 			return
 		}
 


### PR DESCRIPTION
This pull request reorders an if statement to allow for more specific error logging.
Previously, the check for `data.error` was after the check for if the response status did not 200. Therefore, the error from Formbar would never be logged.