### PR TITLE
Clear LED bar when stopping rave mode

### DIFF
--- a/controllers/raveControllers.js
+++ b/controllers/raveControllers.js
@@ -55,7 +55,7 @@ async function raveController(req, res) {
 		const barLength = config.barPixels;
 		let offset = 0;
 		const intensityMultiplier = intensity / 100;
-		
+
 		// Calculate interval timing based on mode and BPM
 		let intervalTiming = speed;
 		if (mode === 'crazy' && bpm !== undefined) {
@@ -63,7 +63,7 @@ async function raveController(req, res) {
 			// For visual effects, use half the beat duration for faster updates
 			intervalTiming = (60000 / bpm) / 2;
 		}
-		
+
 		// Chase mode needs persistent chaser positions and directions
 		const chasers = [
 			{ pos: 0, speed: 2.5, size: 10, hueOffset: 0, dir: 1 },       // Fast red
@@ -75,7 +75,7 @@ async function raveController(req, res) {
 			{ pos: 90, speed: 3.5, size: 7, hueOffset: 30, dir: -1 },     // Orange backwards
 			{ pos: 105, speed: 1.5, size: 14, hueOffset: 200, dir: 1 }    // Teal
 		];
-		
+
 		// Crazy mode tracking
 		let currentCrazyMode = 'rainbow';
 		let modeChangeCounter = 0;
@@ -109,13 +109,13 @@ async function raveController(req, res) {
 				}
 			} else if (mode === 'chase') {
 				// ABSOLUTE CHAOS - bouncing chasers with STROBING BACKGROUND
-				
+
 				// FULL STROBE BACKGROUND - changes every frame
 				const bgHue = Math.random() * 360;
 				const bgRgb = hsvToRgb(bgHue, 0.8, intensityMultiplier * 0.4);
 				const bgColor = (bgRgb.r << 16) | (bgRgb.g << 8) | bgRgb.b;
 				fill(pixels, bgColor, 0, barLength);
-				
+
 				// Additional random strobe sections (40% chance each frame)
 				if (Math.random() < 0.4) {
 					const strobePos = Math.floor(Math.random() * barLength);
@@ -127,19 +127,19 @@ async function raveController(req, res) {
 						pixels[pos] = strobeColor;
 					}
 				}
-				
+
 				// Random sparkles (40% chance)
 				if (Math.random() < 0.4) {
 					const sparklePos = Math.floor(Math.random() * barLength);
 					const sparkleRgb = hsvToRgb(Math.random() * 360, 1, intensityMultiplier);
 					pixels[sparklePos] = (sparkleRgb.r << 16) | (sparkleRgb.g << 8) | sparkleRgb.b;
 				}
-				
+
 				// Update and draw all bouncing chasers
 				for (let chaser of chasers) {
 					// Update position
 					chaser.pos += chaser.speed * chaser.dir;
-					
+
 					// Bounce at edges with explosion effect
 					if (chaser.pos <= 0 || chaser.pos >= barLength - chaser.size) {
 						chaser.dir *= -1;
@@ -153,12 +153,12 @@ async function raveController(req, res) {
 							}
 						}
 					}
-					
+
 					// Clamp position
 					chaser.pos = Math.max(0, Math.min(barLength - chaser.size, chaser.pos));
-					
+
 					const baseHue = ((offset * 15 + chaser.hueOffset) % 360);
-					
+
 					// Draw chaser with intense fading trail
 					for (let i = 0; i < chaser.size; i++) {
 						const pixelPos = Math.floor(chaser.pos + i);
@@ -166,23 +166,23 @@ async function raveController(req, res) {
 							const trailFade = 1 - (i / chaser.size);
 							const hue = (baseHue + i * 8) % 360;
 							const rgb = hsvToRgb(hue, 1, trailFade * intensityMultiplier);
-							
+
 							// Additive blending for insane color mixing
 							const existingR = (pixels[pixelPos] >> 16) & 0xff;
 							const existingG = (pixels[pixelPos] >> 8) & 0xff;
 							const existingB = pixels[pixelPos] & 0xff;
-							
+
 							const newR = Math.min(255, existingR + rgb.r);
 							const newG = Math.min(255, existingG + rgb.g);
 							const newB = Math.min(255, existingB + rgb.b);
-							
+
 							pixels[pixelPos] = (newR << 16) | (newG << 8) | newB;
 						}
 					}
 				}
 			} else if (mode === 'crazy') {
 				// CRAZY MODE - ALL EFFECTS AT ONCE WITH ROTATING MODES
-				
+
 				// Rotate through modes every N frames
 				modeChangeCounter++;
 				if (modeChangeCounter >= modeRotationSpeed) {
@@ -190,9 +190,9 @@ async function raveController(req, res) {
 					const modes = ['rainbow', 'strobe', 'pulse', 'chase'];
 					currentCrazyMode = modes[Math.floor(Math.random() * modes.length)];
 				}
-				
+
 				const midPoint = Math.floor(barLength / 2);
-				
+
 				// Split bar into two halves with different effects
 				if (currentCrazyMode === 'rainbow') {
 					// Left half: forward rainbow
@@ -237,10 +237,10 @@ async function raveController(req, res) {
 					const bgRgb = hsvToRgb(bgHue, 0.8, intensityMultiplier * 0.3);
 					const bgColor = (bgRgb.r << 16) | (bgRgb.g << 8) | bgRgb.b;
 					fill(pixels, bgColor, 0, barLength);
-					
+
 					for (let chaser of chasers) {
 						chaser.pos += chaser.speed * chaser.dir;
-						
+
 						if (chaser.pos <= 0 || chaser.pos >= barLength - chaser.size) {
 							chaser.dir *= -1;
 							// Mini explosion
@@ -253,33 +253,33 @@ async function raveController(req, res) {
 								}
 							}
 						}
-						
+
 						chaser.pos = Math.max(0, Math.min(barLength - chaser.size, chaser.pos));
 						const baseHue = ((offset * 20 + chaser.hueOffset) % 360);
-						
+
 						for (let i = 0; i < chaser.size; i++) {
 							const pixelPos = Math.floor(chaser.pos + i);
 							if (pixelPos >= 0 && pixelPos < barLength) {
 								const trailFade = 1 - (i / chaser.size);
 								const hue = (baseHue + i * 10) % 360;
 								const rgb = hsvToRgb(hue, 1, trailFade * intensityMultiplier);
-								
+
 								const existingR = (pixels[pixelPos] >> 16) & 0xff;
 								const existingG = (pixels[pixelPos] >> 8) & 0xff;
 								const existingB = pixels[pixelPos] & 0xff;
-								
+
 								const newR = Math.min(255, existingR + rgb.r);
 								const newG = Math.min(255, existingG + rgb.g);
 								const newB = Math.min(255, existingB + rgb.b);
-								
+
 								pixels[pixelPos] = (newR << 16) | (newG << 8) | newB;
 							}
 						}
 					}
 				}
-				
+
 				// MAXIMUM CHAOS - Add TONS of random elements every frame
-				
+
 				// Random full-screen glitch (10% chance)
 				glitchCounter++;
 				if (Math.random() < 0.1 || glitchCounter % 7 === 0) {
@@ -289,7 +289,7 @@ async function raveController(req, res) {
 					const glitchRgb = hsvToRgb(glitchHue, 1, intensityMultiplier);
 					fill(pixels, (glitchRgb.r << 16) | (glitchRgb.g << 8) | glitchRgb.b, glitchPos, glitchLength);
 				}
-				
+
 				// Random strobe sections (50% chance) - INCREASED
 				if (Math.random() < 0.5) {
 					const strobePos = Math.floor(Math.random() * barLength);
@@ -302,7 +302,7 @@ async function raveController(req, res) {
 						pixels[pos] = strobeColor;
 					}
 				}
-				
+
 				// Random sparkles EVERYWHERE (60% chance) - INCREASED
 				const sparkleCount = Math.floor(Math.random() * 5) + 3;
 				for (let s = 0; s < sparkleCount; s++) {
@@ -312,7 +312,7 @@ async function raveController(req, res) {
 						pixels[sparklePos] = (sparkleRgb.r << 16) | (sparkleRgb.g << 8) | sparkleRgb.b;
 					}
 				}
-				
+
 				// Random inversion sections (20% chance)
 				if (Math.random() < 0.2) {
 					const invertStart = Math.floor(Math.random() * barLength / 2);
@@ -324,7 +324,7 @@ async function raveController(req, res) {
 						pixels[i] = (r << 16) | (g << 8) | b;
 					}
 				}
-				
+
 				// Random rotating segments (30% chance)
 				if (Math.random() < 0.3) {
 					const segmentSize = 8;
@@ -344,13 +344,13 @@ async function raveController(req, res) {
 						}
 					}
 				}
-				
+
 				// Lightning flash effect (15% chance)
 				if (Math.random() < 0.15) {
 					const flashColor = Math.random() > 0.5 ? 0xFFFFFF : 0xFFFF00;
 					fill(pixels, flashColor, 0, barLength);
 				}
-				
+
 				// Triple split rainbow (25% chance)
 				if (Math.random() < 0.25) {
 					const third = Math.floor(barLength / 3);
@@ -367,7 +367,7 @@ async function raveController(req, res) {
 						pixels[i] = (newR << 16) | (newG << 8) | newB;
 					}
 				}
-				
+
 				// Extra random chaos pixels
 				for (let chaos = 0; chaos < 10; chaos++) {
 					if (Math.random() < 0.4) {
@@ -399,6 +399,11 @@ async function raveStopController(req, res) {
 		if (currentRaveInterval) {
 			clearInterval(currentRaveInterval);
 			currentRaveInterval = null;
+			// Clear the bar when stopping rave mode
+			const { pixels, config, ws281x } = require('../state');
+			const { fill } = require('../utils/pixelOps');
+			fill(pixels, 0x000000, 0, config.barPixels);
+			ws281x.render();
 			logger.info('Rave mode stopped');
 			res.status(200).json({ message: 'ok', mode: 'rave stopped' });
 		} else {
@@ -421,9 +426,9 @@ function hsvToRgb(h, s, v) {
 	const c = v * s;
 	const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
 	const m = v - c;
-	
+
 	let r = 0, g = 0, b = 0;
-	
+
 	if (h >= 0 && h < 60) {
 		r = c; g = x; b = 0;
 	} else if (h >= 60 && h < 120) {
@@ -437,7 +442,7 @@ function hsvToRgb(h, s, v) {
 	} else if (h >= 300 && h < 360) {
 		r = c; g = 0; b = x;
 	}
-	
+
 	return {
 		r: Math.round((r + m) * 255),
 		g: Math.round((g + m) * 255),

--- a/formPixSim/controllers/raveControllers.js
+++ b/formPixSim/controllers/raveControllers.js
@@ -399,6 +399,11 @@ async function raveStopController(req, res) {
 		if (currentRaveInterval) {
 			clearInterval(currentRaveInterval);
 			currentRaveInterval = null;
+			// Clear the bar when stopping rave mode
+			const { pixels, config, ws281x } = require('../state');
+			const { fill } = require('../utils/pixelOps');
+			fill(pixels, 0x000000, 0, config.barPixels);
+			ws281x.render();
 			logger.info('Rave mode stopped');
 			res.status(200).json({ message: 'ok', mode: 'rave stopped' });
 		} else {


### PR DESCRIPTION
When rave mode is stopped, explicitly clear the pixel buffer and render to turn the bar off. Adds code to both controllers/raveControllers.js and formPixSim/controllers/raveControllers.js to require state, call pixelOps.fill(pixels, 0x000000, 0, config.barPixels) and ws281x.render(). Also includes minor whitespace/formatting cleanups across the files.