### PR TITLE
Fixed leaking formpix

### DIFF
--- a/sockets/pollHandlers.js
+++ b/sockets/pollHandlers.js
@@ -155,21 +155,29 @@ function handleClassUpdate() {
 						let color = poll.color
 						if (blind) color = 0xFF8000
 
-						fill(pixels, color, currentPixel, pixelsPerStudent)
-						currentPixel += pixelsPerStudent
+						let pixelsToFill = Math.min(pixelsPerStudent, config.barPixels - currentPixel)
+
+						if (pixelsToFill <= 0) break
+
+						fill(pixels, color, currentPixel, pixelsToFill)
+						currentPixel += pixelsToFill
 
 						if (
 							responseNumber < poll.responses - 1 ||
 							pollNumber < nonEmptyPolls
 						) {
-							pixels[currentPixel] = 0xFF0080
+							if (currentPixel < config.barPixels) {
+								pixels[currentPixel] = 0xFF0080
+							}
 						}
 					}
 
 					if (
 						!blind &&
 						poll.responses > 0
-					) currentPixel++
+					) {
+						if (currentPixel < config.barPixels) currentPixel++
+					}
 					pollNumber++
 				}
 			}
@@ -178,7 +186,9 @@ function handleClassUpdate() {
 				text = `${newPollData.totalResponses}/${newPollData.totalResponders} `
 				if (newPollData.prompt) pollText = newPollData.prompt
 
-				fill(pixels, 0x000000, config.barPixels + getStringColumnLength(text + pollText) * 8)
+				const boardStartPixel = config.barPixels
+				const boardLength = config.boards * 32 * 8
+				fill(pixels, 0x000000, boardStartPixel, boardLength)
 
 				let display = displayBoard(pixels, text, 0xFFFFFF, 0x000000, config, boardIntervals, ws281x)
 				if (display) boardIntervals.push(display)


### PR DESCRIPTION
This pull request improves the robustness and accuracy of pixel filling logic in the poll display bar and ensures proper clearing of the board area in the `handleClassUpdate` function within `sockets/pollHandlers.js`. The changes address edge cases where pixel operations could exceed the intended bounds and clarify how the board area is reset before rendering new text.

**Improvements to pixel bar filling logic:**

* Ensured that the number of pixels filled for each student does not exceed the available bar space by using `Math.min(pixelsPerStudent, config.barPixels - currentPixel)`, and added checks to prevent overfilling or writing out of bounds.
* Added logic to only increment the `currentPixel` and set separator colors if within the bounds of `config.barPixels`, preventing potential out-of-bounds errors.

**Board area clearing and rendering:**

* Changed the board clearing logic to explicitly calculate the start and length of the board area (`boardStartPixel` and `boardLength`) and clear only that region, rather than potentially over-clearing or misaligning the reset area.