### PR TITLE
Make animations time-based and validate fill bounds

### DIFF
--- a/controllers/pixelControllers.js
+++ b/controllers/pixelControllers.js
@@ -310,7 +310,7 @@ async function fillController(req, res) {
 		logger.info('API Call: /api/fill', { query: req.query });
 		const { pixels, config, ws281x } = require('../state');
 
-		let { color, start = 0, length = pixels.length } = req.query
+		let { color, start = 0, length = config.barPixels } = req.query
 
 		color = textToHexColor(color)
 
@@ -331,6 +331,17 @@ async function fillController(req, res) {
 
 		start = Number(start)
 		length = Number(length)
+
+		const barLength = config.barPixels;
+		if (start < 0) start = 0;
+		if (start >= barLength) {
+			res.status(400).json({ error: 'start must be within barPixels' });
+			return;
+		}
+		if (length < 0) length = 0;
+		if (start + length > barLength) {
+			length = barLength - start;
+		}
 
 		fill(pixels, color, start, length)
 		ws281x.render()

--- a/controllers/raveControllers.js
+++ b/controllers/raveControllers.js
@@ -86,7 +86,14 @@ async function raveController(req, res) {
 		// Import fill function
 		const { fill } = require('../utils/pixelOps');
 
+		let lastFrameTime = Date.now();
+
 		currentRaveInterval = setInterval(() => {
+			const now = Date.now();
+			let delta = now - lastFrameTime;
+			lastFrameTime = now;
+			if (!delta || delta < 0) delta = intervalTiming;
+			const offsetStep = Math.max(1, Math.round(delta / intervalTiming));
 			if (mode === 'rainbow') {
 				// Rainbow wave effect
 				for (let i = 0; i < barLength; i++) {
@@ -380,7 +387,7 @@ async function raveController(req, res) {
 				}
 			}
 
-			offset++;
+			offset += offsetStep;
 			ws281x.render();
 		}, intervalTiming);
 

--- a/formPixSim/controllers/pixelControllers.js
+++ b/formPixSim/controllers/pixelControllers.js
@@ -303,7 +303,7 @@ async function fillController(req, res) {
 	try {
 		const { pixels, config, ws281x } = require('../state');
 
-		let { color, start = 0, length = pixels.length } = req.query
+		let { color, start = 0, length = config.barPixels } = req.query
 
 		color = textToHexColor(color)
 
@@ -324,6 +324,17 @@ async function fillController(req, res) {
 
 		start = Number(start)
 		length = Number(length)
+
+		const barLength = config.barPixels;
+		if (start < 0) start = 0;
+		if (start >= barLength) {
+			res.status(400).json({ error: 'start must be within barPixels' });
+			return;
+		}
+		if (length < 0) length = 0;
+		if (start + length > barLength) {
+			length = barLength - start;
+		}
 
 		fill(pixels, color, start, length)
 		ws281x.render()

--- a/formPixSim/controllers/raveControllers.js
+++ b/formPixSim/controllers/raveControllers.js
@@ -140,7 +140,14 @@ async function raveController(req, res) {
 		// Import fill function
 		const { fill } = require('../utils/pixelOps');
 
+		let lastFrameTime = Date.now();
+
 		currentRaveInterval = setInterval(() => {
+			const now = Date.now();
+			let delta = now - lastFrameTime;
+			lastFrameTime = now;
+			if (!delta || delta < 0) delta = intervalTiming;
+			const offsetStep = Math.max(1, Math.round(delta / intervalTiming));
 			if (mode === 'rainbow') {
 				// Rainbow wave effect
 				for (let i = 0; i < barLength; i++) {
@@ -434,7 +441,7 @@ async function raveController(req, res) {
 				}
 			}
 
-			offset++;
+			offset += offsetStep;
 			ws281x.render();
 		}, intervalTiming);
 

--- a/formPixSim/utils/displayUtils.js
+++ b/formPixSim/utils/displayUtils.js
@@ -164,12 +164,19 @@ function displayBoard(pixels, string, textColor, backgroundColor, config, boardI
 		}
 
 		let startFrame = 0;
+		let lastFrameTime = Date.now();
 
 		return {
 			string,
 			interval: setInterval(() => {
+				const now = Date.now();
+				let delta = now - lastFrameTime;
+				lastFrameTime = now;
+				if (!delta || delta < 0) delta = scroll;
+				const frameStep = Math.max(1, Math.round(delta / scroll));
+
 				showString(boardPixels, startFrame, textColor, backgroundColor, pixels, startPixel, endPixel);
-				startFrame = (startFrame + 1) % boardPixels.length;
+				startFrame = (startFrame + frameStep) % boardPixels.length;
 				ws281x.render();
 			}, scroll),
 			startColumn,

--- a/utils/displayUtils.js
+++ b/utils/displayUtils.js
@@ -154,12 +154,19 @@ function displayBoard(pixels, string, textColor, backgroundColor, config, boardI
 		}
 
 		let startFrame = 0;
+		let lastFrameTime = Date.now();
 
 		return {
 			string,
 			interval: setInterval(() => {
+				const now = Date.now();
+				let delta = now - lastFrameTime;
+				lastFrameTime = now;
+				if (!delta || delta < 0) delta = scroll;
+				const frameStep = Math.max(1, Math.round(delta / scroll));
+
 				showString(boardPixels, startFrame, textColor, backgroundColor, pixels, startPixel, endPixel);
-				startFrame = (startFrame + 1) % boardPixels.length;
+				startFrame = (startFrame + frameStep) % boardPixels.length;
 				ws281x.render();
 			}, scroll),
 			startColumn,


### PR DESCRIPTION
Use real-time deltas to advance animation frames and validate fill ranges.

- controllers/* and formPixSim/controllers/*: fillController now defaults length to config.barPixels (not pixels.length) and sanitizes start/length values. It returns 400 if start is outside barPixels and clamps negative/overflow lengths to keep writes in-bounds.
- raveControllers (app + formPixSim): track lastFrameTime, compute delta and an offsetStep = max(1, round(delta/intervalTiming)), and increment offset by offsetStep so animations keep correct speed despite timer drift or slow frames.
- utils/displayUtils.js and formPixSim/utils/displayUtils.js: similar time-based frameStep computed from real deltas for scrolling text; advance startFrame by frameStep instead of 1 to avoid skipped or slow frames.

These changes make animations resilient to interval timing variability and prevent out-of-range pixel operations.