### PR TITLE
Reserve divider pixels and floor bar sizing

### DIFF
--- a/formPixSim/sockets/pollHandlers.js
+++ b/formPixSim/sockets/pollHandlers.js
@@ -174,12 +174,16 @@ function handleClassUpdate(webIo) {
 					totalResponses += poll.responses
 				}
 
+				// Reserve pixels for dividers (one between each response except the last)
+				const dividerCount = totalResponses > 0 ? totalResponses - 1 : 0
+				const availablePixelsForResponses = config.barPixels - dividerCount
+
 				if (newPollData.multiRes) {
 					if (newPollData.totalResponders <= 0) pixelsPerStudent = 0
-					else pixelsPerStudent = Math.ceil((config.barPixels - nonEmptyPolls) / totalResponses / newPollData.totalResponders)
+					else pixelsPerStudent = Math.floor(availablePixelsForResponses / totalResponses / newPollData.totalResponders)
 				} else {
 					if (newPollData.totalResponders <= 0) pixelsPerStudent = 0
-					else pixelsPerStudent = Math.ceil((config.barPixels - nonEmptyPolls) / newPollData.totalResponders)
+					else pixelsPerStudent = Math.floor(availablePixelsForResponses / totalResponses)
 				}
 
 				let currentPixel = 0

--- a/sockets/pollHandlers.js
+++ b/sockets/pollHandlers.js
@@ -154,12 +154,16 @@ function handleClassUpdate() {
 					totalResponses += poll.responses
 				}
 
+				// Reserve pixels for dividers (one between each response except the last)
+				const dividerCount = totalResponses > 0 ? totalResponses - 1 : 0
+				const availablePixelsForResponses = config.barPixels - dividerCount
+
 				if (newPollData.multiRes) {
 					if (newPollData.totalResponders <= 0) pixelsPerStudent = 0
-					else pixelsPerStudent = Math.ceil((config.barPixels - nonEmptyPolls) / totalResponses / newPollData.totalResponders)
+					else pixelsPerStudent = Math.floor(availablePixelsForResponses / totalResponses / newPollData.totalResponders)
 				} else {
 					if (newPollData.totalResponders <= 0) pixelsPerStudent = 0
-					else pixelsPerStudent = Math.ceil((config.barPixels - nonEmptyPolls) / newPollData.totalResponders)
+					else pixelsPerStudent = Math.floor(availablePixelsForResponses / totalResponses)
 				}
 
 				let currentPixel = 0


### PR DESCRIPTION
Reserve one pixel between each response and subtract those divider pixels from the total available bar pixels before computing per-student pixel allocations. Replaced previous (config.barPixels - nonEmptyPolls) usage with availablePixelsForResponses (config.barPixels - dividerCount) and switched Math.ceil to Math.floor when calculating pixelsPerStudent. Also adjusted the single-response branch to divide by totalResponses. Changes made in formPixSim/sockets/pollHandlers.js and sockets/pollHandlers.js to prevent overallocation and ensure space for dividers.