### PR TITLE
Adjust class update handling

### DIFF
--- a/formPixSim/sockets/connectionHandlers.js
+++ b/formPixSim/sockets/connectionHandlers.js
@@ -98,9 +98,10 @@ function handleSetClass(socket, boardIntervals) {
 
 			ws281x.render()
 		} else {
-			logger.info(`Formbar setClass: ${userClassId}`);
+			logger.debug(`Formbar setClass: ${userClassId}`);
 			socket.emit('classUpdate')
 			socket.emit('vbTimer')
+			handleRequestClassUpdate(socket)();
 		}
 
 		state.classId = userClassId;

--- a/sockets/connectionHandlers.js
+++ b/sockets/connectionHandlers.js
@@ -22,8 +22,8 @@ const logger = require('../utils/logger');
  */
 function handleConnectError(socket, boardIntervals) {
 	return (error) => {
-		if (error.message == 'xhr poll error') console.log('no connection');
-		else console.log(error.message);
+		if (error.message == 'xhr poll error') logger.debug('No connection - retrying');
+		else logger.warn(`Socket connection error: ${error.message}`);
 
 		state.connected = false
 
@@ -97,15 +97,9 @@ function handleSetClass(socket, boardIntervals) {
 
 			ws281x.render()
 		} else {
+			logger.debug(`Class update received - New class ID: ${userClassId}`);
 			socket.emit('classUpdate')
 			socket.emit('vbTimer')
-			if (!state.classRefreshed) {
-				state.classRefreshed = true;
-
-				logger.info(`Class update received - New class ID: ${userClassId}`);
-				
-				handleRequestClassUpdate(socket)();
-			}
 		}
 
 		state.classId = userClassId;


### PR DESCRIPTION
Replace console.log calls with structured logger calls and normalize log levels for socket events. In sockets/connectionHandlers.js, console logging is replaced with logger.debug/warn and the previous state.classRefreshed guard and its handleRequestClassUpdate invocation were removed to simplify class update flow. In formPixSim/sockets/connectionHandlers.js, the class-change log was downgraded to debug and an explicit handleRequestClassUpdate(socket)() call was added. These changes standardize logging and consolidate where class refresh requests are triggered.