### PR TITLE
Stop animations and clear display on poll start

### DIFF
--- a/formPixSim/sockets/pollHandlers.js
+++ b/formPixSim/sockets/pollHandlers.js
@@ -9,6 +9,33 @@ const { displayBoard, getStringColumnLength } = require('../utils/displayUtils')
 const PIXELS_PER_LETTER = 5;
 
 /**
+ * Stop active animations and clear the full display (bar + boards).
+ * @param {import('../state')} state - Global state object
+ */
+function stopAnimationsAndClearDisplay(state) {
+	const { pixels, ws281x, boardIntervals } = state
+	const raveController = require('../controllers/raveControllers')
+	const pixelControllers = require('../controllers/pixelControllers')
+
+	if (raveController.currentRaveInterval) {
+		clearInterval(raveController.currentRaveInterval)
+		raveController.currentRaveInterval = null
+	}
+
+	pixelControllers.stopProgressAnimation()
+
+	for (let boardInterval of boardIntervals) {
+		if (boardInterval && boardInterval.interval) {
+			clearInterval(boardInterval.interval)
+		}
+	}
+	boardIntervals.length = 0
+
+	fill(pixels, 0x000000, 0, pixels.length)
+	ws281x.render()
+}
+
+/**
  * @typedef {{fetchSockets: () => Promise<Array<{emit: (event: string, payload?: unknown) => void}>>}} WebIo
  * @typedef {{ poll: Record<string, unknown> }} ClassroomData
  */
@@ -44,8 +71,14 @@ function handleClassUpdate(webIo) {
 
 		const responseCount = newPollData.responses ? Object.keys(newPollData.responses).length : 0;
 		logger.debug(`Formbar classUpdate: status=${newPollData.status}, prompt="${newPollData.prompt || ''}", responses=${newPollData.totalResponses}/${newPollData.totalResponders}, options=${responseCount}, timerActive=${timerData.active}`);
+		const wasPollVisible = !!(pollData.status || (pollData.responses && Object.keys(pollData.responses).length > 0));
 		const pollIsVisible = !!(newPollData.status || (newPollData.responses && Object.keys(newPollData.responses).length > 0));
 		state.pollLockActive = pollIsVisible;
+
+		// On poll start, kill animations and clear the whole display first.
+		if (!wasPollVisible && pollIsVisible) {
+			stopAnimationsAndClearDisplay(state)
+		}
 
 		// Only clear the bar when poll is cleared (no responses), not when it's just ended
 		if (!newPollData.status && (!newPollData.responses || Object.keys(newPollData.responses).length === 0)) {

--- a/sockets/pollHandlers.js
+++ b/sockets/pollHandlers.js
@@ -10,6 +10,33 @@ const { playSound, player } = require('../utils/soundUtils');
 const PIXELS_PER_LETTER = 5;
 
 /**
+ * Stop active animations and clear the full display (bar + boards).
+ * @param {import('../state')} state - Global state object
+ */
+function stopAnimationsAndClearDisplay(state) {
+	const { pixels, ws281x, boardIntervals } = state
+	const raveController = require('../controllers/raveControllers')
+	const pixelControllers = require('../controllers/pixelControllers')
+
+	if (raveController.currentRaveInterval) {
+		clearInterval(raveController.currentRaveInterval)
+		raveController.currentRaveInterval = null
+	}
+
+	pixelControllers.stopProgressAnimation()
+
+	for (let boardInterval of boardIntervals) {
+		if (boardInterval && boardInterval.interval) {
+			clearInterval(boardInterval.interval)
+		}
+	}
+	boardIntervals.length = 0
+
+	fill(pixels, 0x000000, 0, pixels.length)
+	ws281x.render()
+}
+
+/**
  * @typedef {{ poll: Record<string, unknown> }} ClassroomData
  */
 
@@ -31,8 +58,14 @@ function handleClassUpdate() {
 		if (util.isDeepStrictEqual(newPollData, pollData)) return
 
 		logger.debug('Class update received', { pollStatus: newPollData.status, pollPrompt: newPollData.prompt });
+		const wasPollVisible = !!(pollData.status || (pollData.responses && Object.keys(pollData.responses).length > 0));
 		const pollIsVisible = !!(newPollData.status || (newPollData.responses && Object.keys(newPollData.responses).length > 0));
 		state.pollLockActive = pollIsVisible;
+
+		// On poll start, kill animations and clear the whole display first.
+		if (!wasPollVisible && pollIsVisible) {
+			stopAnimationsAndClearDisplay(state)
+		}
 
 		// Only clear the bar when poll is cleared (by the teacher), not when it's just ended
 		if (!newPollData.status && (!newPollData.responses || Object.keys(newPollData.responses).length === 0)) {


### PR DESCRIPTION
This PR will clear all the things on the bar and board stopping all animations before a poll is to be displayed so there so no fight between all the calls.