### PR TITLE
Harden IR remote worker and logging

### DIFF
--- a/app.js
+++ b/app.js
@@ -111,8 +111,9 @@ httpServer.listen(state.config.port, () => {
 	// Set irPin to -1 in .env to disable IR remote
 	if (state.config.irPin !== -1) {
 		const irRemote = new IRRemote(socket, state.config.irPin);
-		irRemote.start();
-		state.irRemote = irRemote;
+		if (irRemote.start()) {
+			state.irRemote = irRemote;
+		}
 	}
 
 	// Gracefully stop IR Remote on process shutdown to cleanup GPIO

--- a/utils/irRemote.js
+++ b/utils/irRemote.js
@@ -80,6 +80,22 @@ class IRRemote {
         this.debounceMs = 200;
         this.running = false;
         this.worker = null;
+        this._disabledAfterFailure = false;
+    }
+
+    /**
+     * Log failure, stop the worker, and drop off global state so IR stays off until restart.
+     */
+    _disableAfterFailure(reason) {
+        if (this._disabledAfterFailure) {
+            return;
+        }
+        this._disabledAfterFailure = true;
+        console.error(`[IR Remote] ${reason} — IR remote disabled (restart app to re-enable)`);
+        this.stop();
+        if (state.irRemote === this) {
+            state.irRemote = null;
+        }
     }
 
     /**
@@ -105,7 +121,10 @@ class IRRemote {
             }
 
             this.worker = new Worker(path.join(__dirname, 'irWorker.js'), {
-                workerData: { pin: this.pin }
+                workerData: {
+                    pin: this.pin,
+                    verbose: process.env.IR_VERBOSE === '1' || process.env.IR_VERBOSE === 'true'
+                }
             });
 
             this.worker.on('message', (msg) => {
@@ -113,7 +132,7 @@ class IRRemote {
                     this.running = true;
                     console.log(`[IR Remote] Listening on GPIO pin ${msg.pin}`);
                 } else if (msg.type === 'error') {
-                    console.error(`[IR Remote] Worker error: ${msg.message}`);
+                    this._disableAfterFailure(`Worker error: ${msg.message}`);
                 } else if (msg.type === 'debug') {
                     console.log(`[IR Remote] ${msg.message}`);
                 } else if (msg.type === 'signal') {
@@ -122,15 +141,14 @@ class IRRemote {
             });
 
             this.worker.on('error', (err) => {
-                console.error(`[IR Remote] Worker crashed: ${err.message}`);
-                this.running = false;
+                this._disableAfterFailure(`Worker crashed: ${err.message}`);
             });
 
             this.worker.on('exit', (code) => {
-                if (code !== 0) {
-                    console.error(`[IR Remote] Worker exited with code ${code}`);
-                }
                 this.running = false;
+                if (code !== 0) {
+                    this._disableAfterFailure(`Worker exited with code ${code}`);
+                }
             });
 
             return true;
@@ -144,8 +162,12 @@ class IRRemote {
      * Handle a decoded IR signal from the worker
      */
     _handleSignal(binarySignal) {
+        if (this._disabledAfterFailure) {
+            return;
+        }
+
         const hexSignal = '0x' + binarySignal.toString(16);
-        console.log(`[IR Remote] Received: ${hexSignal}`);
+        console.log(`[IR Remote] Decoded signal: ${hexSignal}`);
 
         // Debounce
         const now = Date.now();
@@ -164,7 +186,7 @@ class IRRemote {
             }
         }
 
-        console.log(`[IR Remote] Unknown code: ${hexSignal}`);
+        console.log(`[IR Remote] Unknown code (ignored): ${hexSignal}`);
     }
 
     /**
@@ -172,7 +194,7 @@ class IRRemote {
      */
     executeAction(buttonName) {
         if (!this.socket || !this.socket.connected) {
-            console.log('[IR Remote] Socket not connected - cannot execute action');
+            this._disableAfterFailure('Socket not connected; cannot send Formbar request from IR');
             return;
         }
 
@@ -193,22 +215,26 @@ class IRRemote {
                     allowTextResponses: preset.type === 1,
                     allowMultipleResponses: true
                 });
-                console.log(`[IR Remote] Started poll: ${preset.title}`);
+                console.log(
+                    `[IR Remote] OK — sent startPoll request to Formbar (${preset.title}, button ${buttonName})`
+                );
             } catch (err) {
-                console.error('[IR Remote] Failed to emit "startPoll":', err);
+                const detail = err && err.message ? err.message : String(err);
+                this._disableAfterFailure(`startPoll emit failed: ${detail}`);
             }
         } else if (buttonName === 'play_pause') {
             try {
                 const pollEnded = state.pollData && state.pollData.status === false;
                 if (pollEnded) {
                     this.socket.emit('updatePoll', {});
-                    console.log('[IR Remote] updatePoll {} (poll already ended)');
+                    console.log('[IR Remote] OK — sent updatePoll {} to Formbar (poll already ended)');
                 } else {
                     this.socket.emit('updatePoll', { status: false });
-                    console.log('[IR Remote] updatePoll { status: false } (end poll)');
+                    console.log('[IR Remote] OK — sent updatePoll { status: false } to Formbar (end poll)');
                 }
             } catch (err) {
-                console.error('[IR Remote] Failed to emit "updatePoll":', err);
+                const detail = err && err.message ? err.message : String(err);
+                this._disableAfterFailure(`updatePoll emit failed: ${detail}`);
             }
         }
     }
@@ -220,6 +246,7 @@ class IRRemote {
         this.running = false;
 
         if (this.worker) {
+            this.worker.removeAllListeners();
             this.worker.terminate();
             this.worker = null;
         }

--- a/utils/irWorker.js
+++ b/utils/irWorker.js
@@ -19,6 +19,7 @@ try {
 }
 
 const pin = workerData.pin || 27;
+const verbose = Boolean(workerData && workerData.verbose);
 
 try {
     rpio.init({ gpiomem: true, mapping: 'gpio' });
@@ -49,8 +50,9 @@ function getBinary() {
         return null;
     }
 
-    // Pin went LOW — IR signal detected
-    parentPort.postMessage({ type: 'debug', message: 'Signal start detected (pin went LOW)' });
+    if (verbose) {
+        parentPort.postMessage({ type: 'debug', message: 'Signal start detected (pin went LOW)' });
+    }
 
     const pulses = [];
     const startTime = timeNow();
@@ -70,7 +72,9 @@ function getBinary() {
         rpio.usleep(10);
     }
 
-    parentPort.postMessage({ type: 'debug', message: `Captured ${pulses.length} pulses` });
+    if (verbose) {
+        parentPort.postMessage({ type: 'debug', message: `Captured ${pulses.length} pulses` });
+    }
 
     if (pulses.length < 33) {
         return null;
@@ -83,20 +87,24 @@ function getBinary() {
     }
 
     if (binary.length !== 32) {
-        parentPort.postMessage({ type: 'debug', message: `Bad binary length: ${binary.length}` });
+        if (verbose) {
+            parentPort.postMessage({ type: 'debug', message: `Bad binary length: ${binary.length}` });
+        }
         return null;
     }
 
     try {
         const code = parseInt(binary, 2);
-        parentPort.postMessage({ type: 'debug', message: `Decoded: 0x${code.toString(16)}` });
+        if (verbose) {
+            parentPort.postMessage({ type: 'debug', message: `Decoded: 0x${code.toString(16)}` });
+        }
         return code;
     } catch (err) {
         return null;
     }
 }
 
-// Main loop — uses setInterval so the worker event loop can flush messages
+// Main loop — setImmediate keeps the worker event loop free to flush messages
 function irLoop() {
     const signal = getBinary();
     if (signal !== null) {
@@ -106,27 +114,8 @@ function irLoop() {
     setImmediate(irLoop);
 }
 
-parentPort.postMessage({ type: 'debug', message: `Pin ${pin} initial read: ${rpio.read(pin)}` });
-
-// First: raw pin test for 10 seconds to verify rpio can see pin changes
-parentPort.postMessage({ type: 'debug', message: 'Running raw pin test for 10 seconds - press a button now...' });
-let lastVal = rpio.read(pin);
-let changes = 0;
-const testEnd = timeNow() + 10;
-
-while (timeNow() < testEnd) {
-    const val = rpio.read(pin);
-    if (val !== lastVal) {
-        changes++;
-        if (changes <= 10) {
-            parentPort.postMessage({ type: 'debug', message: `Pin changed to ${val} (change #${changes})` });
-        }
-        lastVal = val;
-    }
-    rpio.usleep(10);
+if (verbose) {
+    parentPort.postMessage({ type: 'debug', message: `Pin ${pin} initial read: ${rpio.read(pin)}` });
 }
 
-parentPort.postMessage({ type: 'debug', message: `Raw pin test done. Total changes detected: ${changes}` });
-
-// Now start the normal IR loop
 setImmediate(irLoop);


### PR DESCRIPTION
Add robust failure handling and quieter worker startup for the IR remote.

- Add _disableAfterFailure to log a failure, stop the worker, and clear state.irRemote so IR remains disabled until app restart.
- Only set state.irRemote in app.js if IRRemote.start() succeeds.
- Propagate a verbose flag to the worker (IR_VERBOSE env var) and gate debug messages to reduce noise by default.
- Replace the blocking raw pin test in the worker with an immediate start of the IR loop (setImmediate) to avoid startup stalls.
- Improve log messages to be clearer and mark successful emits; on socket/emit errors, disable IR via the new failure handler.
- Remove worker listeners before termination to prevent lingering handlers.

These changes make the IR feature more resilient to worker crashes, socket or emit errors, and reduce noisy debug output unless explicitly enabled.