### PR TITLE
Prevent idle resets on null setClass events in idleMode

### DIFF
--- a/formPixSim/utils/idleMode.js
+++ b/formPixSim/utils/idleMode.js
@@ -166,14 +166,17 @@ const bumpApiActivity = bumpActivity;
 
 /**
  * When Formbar emits to this Socket.IO client, treat it like `/api` traffic for idle purposes.
+ * Repeating `setClass` with no active class (null / undefined) is ignored so idle can still run
+ * (matches connectionHandlers `handleSetClass` when `userClassId == null`).
  * @param {{ onAny?: (fn: (eventName: string, ...args: unknown[]) => void) => void }} socket
  */
 function registerFormbarSocketIdleReset(socket) {
 	if (!socket || typeof socket.onAny !== 'function') return;
 	if (socket.__formPixIdleOnAny) return;
 	socket.__formPixIdleOnAny = true;
-	socket.onAny((eventName) => {
+	socket.onAny((eventName, ...args) => {
 		if (SOCKET_EVENTS_IGNORED_FOR_IDLE.has(eventName)) return;
+		if (eventName === 'setClass' && args[0] == null) return;
 		bumpActivity();
 	});
 }

--- a/utils/idleMode.js
+++ b/utils/idleMode.js
@@ -166,14 +166,17 @@ const bumpApiActivity = bumpActivity;
 
 /**
  * When Formbar emits to this Socket.IO client, treat it like `/api` traffic for idle purposes.
+ * Repeating `setClass` with no active class (null / undefined) is ignored so idle can still run
+ * (matches connectionHandlers `handleSetClass` when `userClassId == null`).
  * @param {{ onAny?: (fn: (eventName: string, ...args: unknown[]) => void) => void }} socket
  */
 function registerFormbarSocketIdleReset(socket) {
 	if (!socket || typeof socket.onAny !== 'function') return;
 	if (socket.__formPixIdleOnAny) return;
 	socket.__formPixIdleOnAny = true;
-	socket.onAny((eventName) => {
+	socket.onAny((eventName, ...args) => {
 		if (SOCKET_EVENTS_IGNORED_FOR_IDLE.has(eventName)) return;
+		if (eventName === 'setClass' && args[0] == null) return;
 		bumpActivity();
 	});
 }


### PR DESCRIPTION
This pull request updates the idle mode handling logic for Formbar socket events to better align with the connection handler's behavior. Specifically, it ensures that repeated `setClass` events with no active class (i.e., `null` or `undefined`) do not reset the idle timer, preventing unnecessary activity bumps.

Idle mode logic improvements:

* Updated `registerFormbarSocketIdleReset` in both `formPixSim/utils/idleMode.js` and `utils/idleMode.js` to ignore `setClass` events when the class argument is `null` or `undefined`, matching the logic in the connection handler (`handleSetClass`).